### PR TITLE
Adding Firefox support

### DIFF
--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -19,6 +19,7 @@
     ],
     "background": {
         "service_worker": "scripts/background.js",
+        "scripts": ["scripts/background.js"],
         "persistent": false
     },
     "content_scripts": [

--- a/chrome_extension/scripts/background.js
+++ b/chrome_extension/scripts/background.js
@@ -20,7 +20,7 @@ async function executeInsertScript(tabId) {
 
     await chrome.scripting.executeScript({
         target: { tabId: tabId, frameIds: frameIds },
-        function: createDownloadButton,
+        func: createDownloadButton,
     });
 }
 


### PR DESCRIPTION
Thanks for building this!

I added support for Firefox based browsers. Firefox mostly [supports the extensions api](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/) with some minor changes.

Tested and working locally on: 
- Zen version 1.10b (Firefox 136.0.2) (aarch64)
- Arc Version 1.87.0 (60241) Chromium Engine Version 134.0.6998.118

There are some additional steps to publish this to the Mozilla Add-ons store [listed here](https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/). Happy to help with that if you would like.
